### PR TITLE
Update to use CURL if compiled with PHP, fall back to fopen if not.

### DIFF
--- a/utils/whmcs/owp/owp.php
+++ b/utils/whmcs/owp/owp.php
@@ -246,7 +246,17 @@ function _owp_apiCall($method, $params = '')
     if (is_array($params)) {
         $params = http_build_query($params);
     }
-
+    # Check if CURL is compiled with PHP, fall back to fopen if not.
+    if (extension_loaded('curl')) {    
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, "http://$host/api/$method?$params");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        # CURL provides the same base64 encoding as fopen below
+        curl_setopt($ch, CURLOPT_USERPWD, "$user:$password");
+        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        $result = curl_exec($ch);
+        curl_close($ch);
+    } else {  
     $context = stream_context_create(array(
         'http' => array(
             'header'  => "Authorization: Basic " . base64_encode("$user:$password")
@@ -254,7 +264,7 @@ function _owp_apiCall($method, $params = '')
     ));
 
     $result = file_get_contents("http://$host/api/$method?$params", false, $context);
-
+    }
     $doc = simplexml_load_string($result);
 
     return $doc;


### PR DESCRIPTION
There were problems with some users and the WHMCS module when tying to obtain information using the API.  This uses CURL to connect to the API if compiled with PHP or falls back to fopen if it is not.
