### PR TITLE
fail2ban compatible auth warning

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
           end
         end
 
-        logger.warn "Failed login for '#{params[:login]}' from #{request.remote_ip} at #{Time.now.utc}"
+        logger.warn "Failed login for '#{params[:login]}' from #{request.remote_ip} at #{Time.now.strftime('%Y-%m-%d %H:%M:%S')}"
         respond_to do |format|
           format.html { render :json => { :success => false, :message => message } }
           format.iphone { flash.now[:error] = message }


### PR DESCRIPTION
see http://code.google.com/p/ovz-web-panel/issues/detail?id=338)

(regex would be: ^Failed login for .\* from <HOST> at .*$)
