### PR TITLE
Change back the type of identity column in virtual_servers to integer

### DIFF
--- a/db/migrate/20130421012626_undo_change_identity_type_in_virtual_server.rb
+++ b/db/migrate/20130421012626_undo_change_identity_type_in_virtual_server.rb
@@ -1,6 +1,6 @@
 class UndoChangeIdentityTypeInVirtualServer < ActiveRecord::Migration
   def self.up
-    change_column :virtual_servers, :identity, :integer
+    change_column :virtual_servers, :identity, :integer, :limit => nil
   end
 
   def self.down


### PR DESCRIPTION
Having it as a string breaks ordering in the GUI + calculation of the next VEID when creating a new container.

Issue was reported here: https://code.google.com/p/ovz-web-panel/issues/detail?id=504
