### PR TITLE
Add api endpoints

### DIFF
--- a/app/controllers/api/backups_controller.rb
+++ b/app/controllers/api/backups_controller.rb
@@ -1,0 +1,118 @@
+class Api::BackupsController < Api::Base
+  before_filter :is_allowed
+  before_filter :set_server_by_id, :only => [ :list, :list_data, :create ]
+  before_filter :set_backup_by_id, :only => [ :restore, :delete ]
+
+
+  def list
+    render_object_result(backups_list(@virtual_server))
+  end
+
+  def list_data
+    render_object_result(backups_list(@virtual_server))
+  end
+
+  def delete
+    @backup.delete_physically
+    render_object_result({ :success => true })
+  end
+
+  def create
+    hardware_server = @virtual_server.hardware_server
+    render_error :reason => 'backups.limit_reached' if @current_user.limit_reached?(:limit_backups, @virtual_server.backups.count)
+
+    orig_ve_state = @virtual_server.state
+    ve_state = params[:ve_state]
+
+    if 'running' == orig_ve_state
+      case ve_state
+        when 'suspend' then @virtual_server.suspend
+        when 'stop' then @virtual_server.stop
+      end
+    end
+
+    result = @virtual_server.backup
+    job_id = result[:job]['job_id']
+    backup = result[:backup]
+    backup.description = params[:description]
+
+    spawn do
+      job = BackgroundJob.create('backups.create', { :identity => @virtual_server.identity, :host => hardware_server.host })
+
+      while true
+        job_running = false
+        job_running = true if hardware_server.rpc_client.job_status(job_id)['alive']
+        break unless job_running
+        sleep 10
+      end
+
+      job.finish
+      backup.sync_size
+      backup.save
+
+      if 'running' == orig_ve_state
+        case ve_state
+          when 'suspend' then @virtual_server.resume
+          when 'stop' then @virtual_server.start
+        end
+      end
+    end
+
+    render_object_result({ :success => true })
+  end
+
+  def restore
+    orig_ve_state = @virtual_server.state
+    @virtual_server.stop if 'running' == orig_ve_state
+
+    job_id = @backup.restore['job_id']
+
+    spawn do
+      job = BackgroundJob.create('backups.restore', { :identity => @virtual_server.identity, :host => @virtual_server.hardware_server.host })
+
+      while true
+        job_running = false
+        job_running = true if @virtual_server.hardware_server.rpc_client.job_status(job_id)['alive']
+        break unless job_running
+        sleep 10
+      end
+
+      job.finish
+      @virtual_server.start if 'running' == orig_ve_state
+    end
+    render_object_result({ :success => true })
+  end
+
+  private
+
+    def is_allowed
+      render_error :reason => 'access_denied' if !@current_user.superadmin? && !AppConfig.backups.allow_for_users || !@current_user.can_backup_ve?
+    end
+
+    def backups_list(virtual_server)
+      backups = virtual_server.backups
+      backups.map! do |backup|
+        {
+          :id => backup.id,
+          :name => backup.name,
+          :description => backup.description,
+          :size => backup.size,
+          :archive_date => local_datetime(backup.date),
+        }
+      end
+    end
+
+    def set_server_by_id
+      @virtual_server = VirtualServer.find_by_id(params[:id])
+      render_error :reason => 'object_not_found' if !@virtual_server or !@current_user.can_control(@virtual_server)
+    end
+
+    def set_backup_by_id
+      @backup = Backup.find_by_id(params[:id])
+      unless @backup
+        render_error :reason => 'object_not_found' if !@backup
+      else
+        @virtual_server = @backup.virtual_server if !@backup
+      end
+    end
+end

--- a/app/controllers/api/virtual_servers_controller.rb
+++ b/app/controllers/api/virtual_servers_controller.rb
@@ -130,7 +130,7 @@ class Api::VirtualServersController < Api::Base
                 :percent => (counter.held.to_f / counter.limit.to_f * 100).to_i.to_s,
                 :free =>  helper.number_to_human_size(counter.limit.to_i - counter.held.to_i, :locale => :en),
                 :used => helper.number_to_human_size(counter.held.to_i, :locale => :en),
-              :  total => helper.number_to_human_size(counter.limit.to_i, :locale => :en)
+                :total => helper.number_to_human_size(counter.limit.to_i, :locale => :en)
               ),
               'percent' => counter.held.to_f / counter.limit.to_f
             }

--- a/app/controllers/api/virtual_servers_controller.rb
+++ b/app/controllers/api/virtual_servers_controller.rb
@@ -1,6 +1,6 @@
 class Api::VirtualServersController < Api::Base
   before_filter :superadmin_required, :only => [ :delete, :create, :update, :get_by_host ]
-  before_filter :set_server_by_id, :only => [ :get, :get_advanced_limits, :delete, :start, :stop, :restart, :update ]
+  before_filter :set_server_by_id, :only => [ :get, :get_advanced_limits, :delete, :start, :stop, :restart, :update, :get_stats ]
 
   def own_servers
     virtual_servers = @current_user.virtual_servers
@@ -45,6 +45,10 @@ class Api::VirtualServersController < Api::Base
     create_or_update_server
   end
 
+  def get_stats
+    render_object_result get_usage_stats(@virtual_server)
+  end
+
   private
 
     def set_server_by_id
@@ -78,4 +82,66 @@ class Api::VirtualServersController < Api::Base
       render_object_save_result(@virtual_server.save_physically, @virtual_server)
     end
 
+    def get_usage_stats(virtual_server)
+        is_running = 'running' == virtual_server.real_state
+
+        stats = []
+
+        counter = Watchdog.get_ve_counter('_cpu_usage', virtual_server.id)
+
+        if counter and is_running
+          stats << {
+            :parameter => "cpu_load_average",
+            :value => {
+              'text' => "#{counter.held}%",
+              'percent' => counter.held.to_f / 100,
+            }
+          }
+        else
+          stats << { :parameter => "cpu_load_average', :value => '-' }
+        end
+
+        helper = Object.new.extend(ActionView::Helpers::NumberHelper)
+
+        counter = Watchdog.get_ve_counter('_diskspace', virtual_server.id)
+
+        if counter and is_running and (counter.limit.to_i > 0)
+          stats << {
+            :parameter => "disk_space",
+            :value => {
+              'text' => t(
+                'admin.virtual_servers.stats.value.disk_usage',
+                :percent => (counter.held.to_f / counter.limit.to_f * 100).to_i.to_s,
+                :free =>  helper.number_to_human_size(counter.limit.to_i - counter.held.to_i, :locale => :en),
+                :used => helper.number_to_human_size(counter.held.to_i, :locale => :en),
+              :  total => helper.number_to_human_size(counter.limit.to_i, :locale => :en)
+              ),
+              'percent' => counter.held.to_f / counter.limit.to_f
+            }
+          }
+        else
+          stats << { :parameter => "disk_space", :value => '-' }
+        end
+
+        counter = Watchdog.get_ve_counter('_memory', virtual_server.id)
+
+        if counter and is_running and (counter.limit.to_i > 0)
+          stats << {
+            :parameter => "memory",
+            :value => {
+              'text' => t(
+                'admin.virtual_servers.stats.value.memory_usage',
+                :percent => (counter.held.to_f / counter.limit.to_f * 100).to_i.to_s,
+                :free =>  helper.number_to_human_size(counter.limit.to_i - counter.held.to_i, :locale => :en),
+                :used => helper.number_to_human_size(counter.held.to_i, :locale => :en),
+                :total => helper.number_to_human_size(counter.limit.to_i, :locale => :en)
+              ),
+              'percent' => counter.held.to_f / counter.limit.to_f
+            }
+          }
+        else
+          stats << { :parameter => "memory", :value => '-' }
+        end
+        stats
+      end
 end

--- a/app/controllers/api/virtual_servers_controller.rb
+++ b/app/controllers/api/virtual_servers_controller.rb
@@ -98,7 +98,7 @@ class Api::VirtualServersController < Api::Base
             }
           }
         else
-          stats << { :parameter => "cpu_load_average', :value => '-' }
+          stats << { :parameter => 'cpu_load_average', :value => '-' }
         end
 
         helper = Object.new.extend(ActionView::Helpers::NumberHelper)
@@ -107,7 +107,7 @@ class Api::VirtualServersController < Api::Base
 
         if counter and is_running and (counter.limit.to_i > 0)
           stats << {
-            :parameter => "disk_space",
+            :parameter => 'disk_space',
             :value => {
               'text' => t(
                 'admin.virtual_servers.stats.value.disk_usage',
@@ -127,7 +127,7 @@ class Api::VirtualServersController < Api::Base
 
         if counter and is_running and (counter.limit.to_i > 0)
           stats << {
-            :parameter => "memory",
+            :parameter => 'memory',
             :value => {
               'text' => t(
                 'admin.virtual_servers.stats.value.memory_usage',


### PR DESCRIPTION
This patch adds API endpoints to manage backups (/api/backup/{list, list_data, create, delete, restore}
and fetch status of a virtual server (/api/virtual_servers/{get_stats?id=X, reinstall})

Arguments for backups/create are:
 - id (virtual server ID)
 - description (shown in web panel and in list_data)
 - ve_state ("live", "stop", "suspend") State the virtual server will be put during the backup

Arguments for `backups/delete` are:
 - id (of the backup)

Arguments for `backups/restore` are:
 - id (of the backup)

Arguments for `/virtual_servers/reinstall` are:
 - id: ID of the virtual server
 - password: the new password for root user
 - orig_os_template: the original template name, i.e. centos-7-x86_64-minimal

Fixes #51 