### PR TITLE
Updating apt-get install command.

### DIFF
--- a/installer/ai.sh
+++ b/installer/ai.sh
@@ -79,7 +79,7 @@ resolve_deps() {
 
   if [ "$DISTRIB_ID" = "Ubuntu" -o "$DISTRIB_ID" = "Debian" ]; then
     apt-get update
-    apt-get -y install ruby rubygems libsqlite3-ruby libopenssl-ruby rake
+    apt-get -y install ruby1.8 rubygems libsqlite3-ruby libruby1.8  rake
   fi
 
   if [ "$DISTRIB_ID" = "RedHat" -o "$DISTRIB_ID" = "CentOS" ]; then


### PR DESCRIPTION
Updating apt-get command so it actually install the correct version of Ruby on Debian 7+ servers.
From Debian 7 the package ruby install Ruby 1.9 and so does libopenssl-ruby, besides, libopenssl-ruby is now obsolete and libruby/libruby1.8 should be installed instead.