### PR TITLE
You can't reinstall 2+ containers in the same time

### DIFF
--- a/app/models/virtual_server.rb
+++ b/app/models/virtual_server.rb
@@ -176,7 +176,7 @@ class VirtualServer < ActiveRecord::Base
   def reinstall
     was_running = 'running' == real_state
     path = '/etc/vz/conf'
-    tmp_template = "tmp.template"
+    tmp_template = "#{shellescape(identity.to_s)}tmp.template"
 
     new_os_template = ""
     if orig_os_template_changed?


### PR DESCRIPTION
when two or more users reinstall containers, one (or more) of this CT will be broken, because every operation uses same temp file. This issue occurs on my server with 500+ CT on it, every few days. This simple patch fix it.

After my patch, every user will have separate temp file, and multiple reinstalls in same time will be possible.

This is first pull-request in my life, so sorry if I'm doing something wrong :)